### PR TITLE
Add scripts to make it easier for contributors to keep codestyle consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,16 @@ const logger = require('./modules/logger')('request-promise-retry');
 
 class rpRetry {
     static _rpRetry(options) {
-        if(options.verbose_logging) {
-          logger.info(`calling ${options.uri} with retry ${options.retry}`);
+        if (options.verbose_logging) {
+            logger.info(`calling ${options.uri} with retry ${options.retry}`);
         }
         const tries = options.retry || 1;
         delete options.retry;
         const fetchDataWithRetry = tryCount => {
             return requestPromise(options)
                 .then(result => {
-                    if(options.verbose_logging) {
-                      logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
+                    if (options.verbose_logging) {
+                        logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
                     }
                     return Promise.resolve(result);
                 })
@@ -31,13 +31,13 @@ class rpRetry {
     }
 
     static _rp(options) {
-        if(options.verbose_logging) {
-          logger.info(`calling ${options.uri} without retries`);
+        if (options.verbose_logging) {
+            logger.info(`calling ${options.uri} without retries`);
         }
         return requestPromise(options)
             .then(result => {
-                if(options.verbose_logging) {
-                  logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
+                if (options.verbose_logging) {
+                    logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
                 }
                 return Promise.resolve(result);
             })

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "node_modules/gulp/bin/gulp.js test",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "eslint": "eslint test/. index.js",
-    "eslint-fix": "eslint test/. index.js --fix"
+    "lint-check": "gulp check",
+    "lint-fix": "gulp fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "node_modules/gulp/bin/gulp.js test",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
+    "eslint": "eslint test/. index.js",
+    "eslint-fix": "eslint test/. index.js --fix"
   },
   "repository": {
     "type": "git",
@@ -45,6 +47,7 @@
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
     "coveralls": "^3.0.0",
+    "eslint": "^5.5.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^4.0.0",
     "gulp-if": "^2.0.2",


### PR DESCRIPTION
I didn't really want to adjust manually the formatting on my previous PR #6 :smile:, so I added those scripts to make it easier for contributors.

This way, people can just type `npm run eslint-fix` and be sure the code is formatted as the existing .eslintrc is defining the style.