### PR TITLE
Adds "accepted" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ var options = {
     headers: {
         'User-Agent': 'Request-Promise'
     },
-    json: true // Automatically parses the JSON string in the response, 
-    retry : 2 // will retry the call twice, in case of error.
-    verbose_logging : false // will log errors only, if set to be true, will log all actions
+    json: true, // Automatically parses the JSON string in the response, 
+    retry : 2, // will retry the call twice, in case of error.
+    verbose_logging : false, // will log errors only, if set to be true, will log all actions
+    accepted: [ 400, 404 ] // Accepted HTTP Status codes (will not retry if request response has any of these HTTP Status Code)
 };
 
 rp(options)

--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ class rpRetry {
                     return Promise.resolve(result);
                 })
                 .catch(err => {
+                    err.accepted = false;
+                    if (options.accepted && options.accepted.indexOf(err.statusCode) > -1) {
+                        err.accepted = true;
+                        return Promise.reject(err);
+                    }
+
                     logger.info(`Encountered error ${err.message} for ${options.method} request to ${options.uri}, retry count ${tryCount}`);
                     tryCount -= 1;
                     if (tryCount) {

--- a/index.js
+++ b/index.js
@@ -5,16 +5,16 @@ const logger = require('./modules/logger')('request-promise-retry');
 
 class rpRetry {
     static _rpRetry(options) {
-        if(options.verbose_logging) {
-          logger.info(`calling ${options.uri} with retry ${options.retry}`);
+        if (options.verbose_logging) {
+            logger.info(`calling ${options.uri} with retry ${options.retry}`);
         }
         const tries = options.retry || 1;
         delete options.retry;
         const fetchDataWithRetry = tryCount => {
             return requestPromise(options)
                 .then(result => {
-                    if(options.verbose_logging) {
-                      logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
+                    if (options.verbose_logging) {
+                        logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
                     }
                     return Promise.resolve(result);
                 })
@@ -37,13 +37,13 @@ class rpRetry {
     }
 
     static _rp(options) {
-        if(options.verbose_logging) {
-          logger.info(`calling ${options.uri} without retries`);
+        if (options.verbose_logging) {
+            logger.info(`calling ${options.uri} without retries`);
         }
         return requestPromise(options)
             .then(result => {
-                if(options.verbose_logging) {
-                  logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
+                if (options.verbose_logging) {
+                    logger.info(`Result obtained for ${options.method} request to ${options.uri}`);
                 }
                 return Promise.resolve(result);
             })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,6 +46,18 @@ const optionsBooleanRetry = {
     method: 'GET',
     retry: true
 };
+const optionsDontRetryAcceptedOptions = {
+    uri: 'https://httpstat.us/404',
+    method: 'GET',
+    retry: true,
+    accepted: [404]
+};
+const optionsRetryWithAcceptedOptions = {
+    uri: 'https://httpstat.us/500',
+    method: 'GET',
+    retry: true,
+    accepted: [404]
+};
 
 describe('request-promise-retry', function () {
     it('should  pass, with retry options', () => {
@@ -100,6 +112,18 @@ describe('request-promise-retry', function () {
         return rp(optionsBooleanRetry)
             .then(data => {
                 expect(data.error).equal(undefined);
+            });
+    });
+    it('should not retry, accepted options enabled', () => {
+        return rp(optionsDontRetryAcceptedOptions)
+            .catch(data => {
+                expect(data.accepted).equal(true);
+            });
+    });
+    it('should retry, accepted options enabled', () => {
+        return rp(optionsRetryWithAcceptedOptions)
+            .catch(data => {
+                expect(data.accepted).equal(false);
             });
     });
 });


### PR DESCRIPTION
In some cases, for example, a 404 Not Found response, maybe another retry should not be the best thing to do, because probably the second request will give 404 again. With that, you can lose some performance.

So, I decided to add a new option called "accepted" that will reject immediately the request if the HTTP Status Code is included in the option.accepted (Array of Number), improving performance.

I also fixed some ESLINT errors on index.